### PR TITLE
Introduce naming conventions

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,12 @@
-<!-- If you are suggesting changes to existing mappings (fields, methods, or parameters) please
-         include the class name, SRG name, existing MCP name, and desired MCP name for each
-         desired change. You are not required to use the suggested format below, but it is
-         encouraged.
+<!-- 
+Please consult our conventions (https://github.com/ModCoderPack/MCPBot-Issues/blob/master/CONVENTIONS.md)
+before suggesting names.
+
+If you are suggesting changes to existing mappings (fields, methods, or parameters) please
+include the class name, SRG name, existing MCP name, and desired MCP name for each
+desired change. You are not required to use the suggested format below, but it is
+encouraged.
+
 Example:
 - [ ] `field_72450_a` in `net.minecraft.util.math.Vec3d`: `xCoord` -> `x`
 - [ ] `field_72448_b` in `net.minecraft.util.math.Vec3d`: `yCoord` -> `y`

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -11,7 +11,7 @@ Getting Started
  - Names should reflect intent, *not* implementation. Check usages rather than just looking at the definition.
  - Names should be concise and memorable. If information can be inferred from context (type, parameters etc.),
    do not include it in the name. This especially applies to fields and methods in a class, where you do not
-   need to have the class name in the member's name.
+   need to have the defining class's name in the member's name.
  - Prefer clarification in the documentation comment over verbose names. Conversely, do not give fields,
    methods, or method parameters useless comments.
 
@@ -40,7 +40,7 @@ Type Names
 do *not* fall under the suffix convention.
 
 ### Examples
- - For a new shelf block with an inventory, appropriate names would be `BlockShelf`, `ShelfTileEntity` and
+ - For a new shelf block with an inventory, appropriate names would be `BlockShelf`, `TileEntityShelf` and
    `ShelfContainer`.
 
 Field Names

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,81 +1,101 @@
-MCP Naming Conventions
-======================
+MCP Naming Rules & Conventions
+==============================
 
+> The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
+
+Introduction
+------------
 In order to guarantee a consistent style and theme across MCP names, the following conventions
-should be adhered to when mapping new things or proposing replacements for existing mappings.
+SHOULD be adhered to when mapping new things or proposing replacements for existing mappings.
+
+Current mappings MAY deviate from this scheme, but you MUST NOT follow their naming convention when proposing new names. Instead you SHOULD try to fix the old names.
+
 Please refer to this document whenever you do not know how to format or structure a name.
 
 Getting Started
 ---------------
- - **If you do not know what to name something then *do not name it*. Let someone else do so.**
- - Names should reflect intent, *not* solely implementation. Check usages rather than looking only at the definition.
+ - **If you do not know what to name something then *you SHOULD NOT name it*. Let someone else do so.**
+ - Names SHOULD reflect intent, *not* solely implementation. Check usages rather than looking only at the definition.
    Also consider overrides and their context.
- - Names should be concise and memorable. If information can be inferred from context (type, parameters etc.),
+ - Names SHOULD be concise and memorable. If information can be inferred from context (type, parameters etc.),
    do not include it in the name. This especially applies to fields and methods in a class, where you do not
    need to have the defining class's name in the member's name.
- - Prefer clarification in the documentation comment over verbose names. Conversely, do not give fields,
-   methods, or method parameters needless comments that only repeat signature and name. Instead, use the documentation
+ - Clarification SHOULD preferably reside in the documentation comment, not in verbose names. Conversely, you SHOULD NOT give fields, methods, or method parameters needless comments that only repeat signature and name. Instead, use the documentation
    for non-trivial examples or technical details.
 
 General
 -------
- - All names use American English spelling.
- - Acronyms should generally be written all-lowercase, while normal camel case rules still apply.
+ - All names MUST use American English spelling.
+ - Acronyms SHOULD generally be written all-lowercase, while normal camel case rules still apply.
    For instance, "identifier" becomes `id` as standalone word or at the beginning of a camel case phrase and
    `Id` when used within a phrase.<br>
    There are various exceptions to this rule which apply only when the word does not start with them:
      - axis-aligned bounding boxes: `AxisAlignedBB` → `AABB`
-     - named binary tags: `NBT`
+     - named binary tags → `NBT`
      - red, green, blue (and alpha) color components → `RGB(A)`
+     - universally unique identifiers: `UUID` → `UniqueId`
+ - Redundancy SHOULD be avoided when possible. If part of a name can be inferred from the surrounding context (class, method, etc.), it SHOULD NOT be included.
+
+### Examples
+ - A class for RGB values SHOULD be called `RGBColor`, not `RgbColour`.
+ - A method for adding something to a container SHOULD be called `Container.add`, not `Container.addToContainer`, as that information can be inferred from the class name.
 
 Type Names
 ----------
- - New classes, interfaces etc. should follow a suffix-based naming scheme.
-   Specifically, this means for any name, `NameType` would be the correct name, where `Type` should be
+ - Type names MUST be named in `UpperCamelCase`.
+ - Classes, interfaces etc. MUST follow a suffix-based naming scheme.
+   Specifically, this means for any name, `NameType` would be the correct name, where `Type` SHOULD be
    derived from the supertypes.
- - Abstract base classes should be prefixed with `Abstract`.
- - Interfaces are prefixed with the letter `I`.
- - Enums should be named directly after the things they are enumerating, in singular form.
-   There is no `Enum` prefix/suffix.
-
-**Note:** Long-established names where prefixes are used (subclasses `Block`, `Item` etc.)
-do *not* fall under the suffix convention.
+ - Abstract base classes SHOULD be prefixed with `Abstract`.
+ - Interfaces MUST be prefixed with the letter `I`.
+ - Enums SHOULD be named directly after the things they are enumerating, in singular form.
+   There MUST NOT be an `Enum` prefix/suffix.
 
 ### Examples
- - For a new shelf block with an inventory, appropriate names would be `BlockShelf`, `TileEntityShelf` and
+ - For a new shelf block with an inventory, appropriate names would be `ShelfBlock`, `ShelfTileEntity` and
    `ShelfContainer`.
+ - An enumeration for dye colors would be called `DyeColor`.
 
 Field Names
 -----------
- - `boolean` type fields should *not* start with an *is* prefix unless there is a convincing reason to do so.
- - No prefixes like `the` or suffixes like `Obj`.
+ - Instance and non-final static fields MUST follow the `camelCase` scheme.
+ - `final static` fields (constants) MUST use `CONSTANT_CASE`.
+ - `boolean` type fields SHOULD NOT start with an *is* prefix unless there is a convincing reason to do so.
+ - Field names MUST NOT use prefixes or suffixes like `the` or `Obj`.
 
 Method Names
 ------------
- - Method names should always start with a verb. Standard conventions for setters and getters apply.
- - Getter-style methods returning a `boolean` should be named with a phrase that can be used
-   in a conditional (if) clause, i.e. some verb or adjective prefixed with some third person verb.
+ - Methods MUST be named using `camelCase`.
+ - Method names SHOULD always start with a verb. Standard conventions for setters and getters apply.
+ - Getter-style methods returning a `boolean` SHOULD be named with a phrase that can be used
+   in a conditional (if) clause, e.g. some verb or adjective prefixed with some third person verb.
    Common prefixes include `is`, `can`, `has`, and `contains`.
- - 'Event handling' methods should follow an `on<Noun>` theme where the noun is the event's name
+ - 'Event handling' methods SHOULD follow an `on<Noun>` theme where the noun is the event's name
    (with redundancies removed).
- - Methods which store an object's state in a provided container should be prefixed with `write`.
+ - Methods which store an object's state in a provided container SHOULD be prefixed with `write`.
    This especially applies to methods that write to some NBT tag or the network buffer.
  - Methods which retrieve an object's state from a provided container and apply it to an existing instance
-   should be prefixed with `read`. This especially applies to methods that read from an NBT tag or
+   SHOULD be prefixed with `read`. This especially applies to methods that read from an NBT tag or
    the network buffer.
  - Methods which convert an object's state into some storage format or reconstruct an object from a given
-   storage container should have a `deserialize` or `serialize` prefix accordingly.
+   storage container SHOULD have a `deserialize` or `serialize` prefix accordingly.
    This applies to methods that perform conversions from an object into JSON/NBT and back,
    without manipulating some provided container or existing object instance.
 
 ### Examples
- - The method for handling block right clicks is called `onActivation` (noun form, no redundancy),
+ - A boolean getter to check whether a chest was opened in the last few seconds SHOULD be called `wasOpenedRecently`.
+ - The method for handling block right clicks SHOULD be called `onActivation` (noun form, no redundancy),
    not `onBlockActivated` (past participle, redundant `Block` infix).
 
 Method Parameter Names
 ----------------------
- - If a name clashes with that of a field or a type name, it should be suffixed with `In`.
- - Parameters of certain types should get named according to the following list:
-     - `BlockPos` arguments should be named `pos` when the usage is obvious and `<subject>Pos` when
-       there is ambiguity or multiple parameters.
-     - Parameters of the `IWorldReaderBase` and related types should be called `worldIn`.
+ - Parameters MUST follow the `camelCase` scheme.
+ - If a name clashes with that of a field or a type name, it SHOULD be suffixed with `In`.
+ - Parameters of certain types SHOULD get named according to the following list:
+     - `BlockPos` arguments SHOULD be named `pos` when the usage is obvious and `<subject>Pos` when
+       there is ambiguity, multiple parameters or the parameter is known to represent something that can not be gleaned from the method name.
+     - Parameters of the `IWorldReaderBase` and related types SHOULD be called `worldIn`. You MAY name it differently if the parameter has a known purpose.
+
+### Examples
+ - The `World` parameter to a method like `Block.onActivation` SHOULD be called `worldIn`.
+ - The two `BlockPos` parameters to a method that calculates the volume of a block cuboid SHOULD be called `startPos` and `endPos`.

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -17,7 +17,7 @@ Getting Started
  - **If you do not know what to name something then *you SHOULD NOT name it*. Let someone else do so.**
  - Names SHOULD reflect intent, *not* solely implementation. Check usages rather than looking only at the definition.
    Also consider overrides and their context.
- - Names SHOULD be concise and memorable. If information can be inferred from context (type, parameters etc.),
+ - Names SHOULD be concise and memorable, while redundancies SHOULD be avoided. If information can be inferred from context (type, parameters etc.),
    do not include it in the name. This especially applies to fields and methods in a class, where you do not
    need to have the defining class's name in the member's name.
  - Clarification SHOULD preferably reside in the documentation comment, not in verbose names. Conversely, you SHOULD NOT give fields, methods, or method parameters needless comments that only repeat signature and name. Instead, use the documentation
@@ -34,7 +34,6 @@ General
      - named binary tags → `NBT`
      - red, green, blue (and alpha) color components → `RGB(A)`
      - universally unique identifiers: `UUID` → `UniqueId`
- - Redundancy SHOULD be avoided when possible. If part of a name can be inferred from the surrounding context (class, method, etc.), it SHOULD NOT be included.
 
 ### Examples
  - A class for RGB values SHOULD be called `RGBColor`, not `RgbColour`.

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -5,15 +5,19 @@ In order to guarantee a consistent style and theme across MCP names, the followi
 should be adhered to when mapping new things or proposing replacements for existing mappings.
 Please refer to this document whenever you do not know how to format or structure a name.
 
-General Conventions
--------------------
- - If you do not know what to name something then *do not name it*. Let someone else name it.
- - All names use US spelling.
- - Names should reflect intent, *not* implementation.
+Getting Started
+---------------
+ - **If you do not know what to name something then *do not name it*. Let someone else do so.**
+ - Names should reflect intent, *not* implementation. Check usages rather than just looking at the definition.
  - Names should be concise and memorable. If information can be inferred from context (type, parameters etc.),
-   do not include it in the name.
+   do not include it in the name. This especially applies to fields and methods in a class, where you do not
+   need to have the class name in the member's name.
  - Prefer clarification in the documentation comment over verbose names. Conversely, do not give fields,
    methods, or method parameters useless comments.
+
+General
+-------
+ - All names use US spelling.
  - Acronyms should generally be written all-lowercase, while normal camel case rules still apply.
    For instance, "identifier" becomes `id` as standalone word or at the beginning of a camel case phrase and
    `Id` when used within a phrase.<br>
@@ -65,7 +69,7 @@ Method Names
 
 Method Parameter Names
 ----------------------
- - If a name clashes with that of a field or a type name, it should be prefixed with `in`
+ - If a name clashes with that of a field or a type name, it should be suffixed with `In`
  - Parameters of certain types should always get named according to the following list:
      - `BlockPos` arguments should be named `pos` when there is a single one, and `*Pos` when there are multiple
      - Parameters of the `IWorldReaderBase` and related type should be `worldIn`

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,0 +1,71 @@
+MCP Naming Conventions
+======================
+
+In order to guarantee a consistent style and theme across MCP names, the following conventions
+should be adhered to when mapping new things or proposing replacements for existing mappings.
+Please refer to this document whenever you do not know how to format or structure a name.
+
+General Conventions
+-------------------
+ - If you do not know what to name something then *do not name it*. Let someone else name it.
+ - All names use US spelling.
+ - Names should reflect intent, *not* implementation.
+ - Names should be concise and memorable. If information can be inferred from context (type, parameters etc.),
+   do not include it in the name.
+ - Prefer clarification in the documentation comment over verbose names. Conversely, do not give fields,
+   methods, or method parameters useless comments.
+ - Acronyms should generally be written all-lowercase, while normal camel case rules still apply.
+   For instance, "identifier" becomes `id` as standalone word or at the beginning of a camel case phrase and
+   `Id` when used within a phrase.<br>
+   There are various exceptions to this rule which apply only when the word does not start with them:
+     - axis-aligned bounding boxes: `AxisAlignedBB` → `AABB`
+     - named binary tags: `NBT`
+     - red, green, blue (and alpha) color components → `RGB(A)`
+
+Type Names
+----------
+ - New classes, interfaces etc. should follow a suffix-based naming scheme.
+   Specifically, this means for any name, `NameType` would be the correct name, where `Type` should be
+   derived from the supertypes.
+ - Abstract base classes should be prefixed with `Abstract`.
+ - Interfaces are prefixed with the letter `I`.
+ - Enums should be named directly after the things they are enumerating, in singular form.
+   There is no `Enum` prefix/suffix.
+
+**Note:** Long-established names where prefixes are used (subclasses `Block`, `Item` etc.)
+do *not* fall under the suffix convention.
+
+### Examples
+ - For a new shelf block with an inventory, appropriate names would be `BlockShelf`, `ShelfTileEntity` and
+   `ShelfContainer`.
+
+Field Names
+-----------
+ - `boolean` type fields should *not* start with an *is* prefix unless there is a convincing reason to do so.
+ - No prefixes like `the` or suffixes like `Obj`.
+
+Method Names
+------------
+ - Method names should always start with a verb. Standard conventions for setters and getters apply.
+ - Methods returning a `boolean` should have a name beginning with an appropriate prefix from the following list:
+     - `can` 
+     - `does`
+     - `has`
+     - `is`
+     - `should`
+     - `was`
+ - 'Event handling' methods should follow an `on<Noun>` theme where the noun is the event's name
+   (with redundancies removed).
+ - Methods which read or write NBT should be prefixed `read` and `write` respectively.
+ - Methods which deseralize or serialize JSON should have a `deserialize` or `serialize` prefix accordingly. 
+
+### Examples
+ - The method for handling block right clicks is called `onActivation` (noun form, no redundancy),
+   not `onBlockActivated` (past participle, redundant `Block` infix).
+
+Method Parameter Names
+----------------------
+ - If a name clashes with that of a field or a type name, it should be prefixed with `in`
+ - Parameters of certain types should always get named according to the following list:
+     - `BlockPos` arguments should be named `pos` when there is a single one, and `*Pos` when there are multiple
+     - Parameters of the `IWorldReaderBase` and related type should be `worldIn`

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -8,16 +8,18 @@ Please refer to this document whenever you do not know how to format or structur
 Getting Started
 ---------------
  - **If you do not know what to name something then *do not name it*. Let someone else do so.**
- - Names should reflect intent, *not* implementation. Check usages rather than just looking at the definition.
+ - Names should reflect intent, *not* solely implementation. Check usages rather than looking only at the definition.
+   Also consider overrides and their context.
  - Names should be concise and memorable. If information can be inferred from context (type, parameters etc.),
    do not include it in the name. This especially applies to fields and methods in a class, where you do not
    need to have the defining class's name in the member's name.
  - Prefer clarification in the documentation comment over verbose names. Conversely, do not give fields,
-   methods, or method parameters useless comments.
+   methods, or method parameters needless comments that only repeat signature and name. Instead, use the documentation
+   for non-trivial examples or technical details.
 
 General
 -------
- - All names use US spelling.
+ - All names use American English spelling.
  - Acronyms should generally be written all-lowercase, while normal camel case rules still apply.
    For instance, "identifier" becomes `id` as standalone word or at the beginning of a camel case phrase and
    `Id` when used within a phrase.<br>
@@ -51,17 +53,20 @@ Field Names
 Method Names
 ------------
  - Method names should always start with a verb. Standard conventions for setters and getters apply.
- - Methods returning a `boolean` should have a name beginning with an appropriate prefix from the following list:
-     - `can` 
-     - `does`
-     - `has`
-     - `is`
-     - `should`
-     - `was`
+ - Getter-style methods returning a `boolean` should be named with a phrase that can be used
+   in a conditional (if) clause, i.e. some verb or adjective prefixed with some third person verb.
+   Common prefixes include `is`, `can`, `has`, and `contains`.
  - 'Event handling' methods should follow an `on<Noun>` theme where the noun is the event's name
    (with redundancies removed).
- - Methods which read or write NBT should be prefixed `read` and `write` respectively.
- - Methods which deseralize or serialize JSON should have a `deserialize` or `serialize` prefix accordingly. 
+ - Methods which store an object's state in a provided container should be prefixed with `write`.
+   This especially applies to methods that write to some NBT tag or the network buffer.
+ - Methods which retrieve an object's state from a provided container and apply it to an existing instance
+   should be prefixed with `read`. This especially applies to methods that read from an NBT tag or
+   the network buffer.
+ - Methods which convert an object's state into some storage format or reconstruct an object from a given
+   storage container should have a `deserialize` or `serialize` prefix accordingly.
+   This applies to methods that perform conversions from an object into JSON/NBT and back,
+   without manipulating some provided container or existing object instance.
 
 ### Examples
  - The method for handling block right clicks is called `onActivation` (noun form, no redundancy),
@@ -69,7 +74,8 @@ Method Names
 
 Method Parameter Names
 ----------------------
- - If a name clashes with that of a field or a type name, it should be suffixed with `In`
- - Parameters of certain types should always get named according to the following list:
-     - `BlockPos` arguments should be named `pos` when there is a single one, and `*Pos` when there are multiple
-     - Parameters of the `IWorldReaderBase` and related type should be `worldIn`
+ - If a name clashes with that of a field or a type name, it should be suffixed with `In`.
+ - Parameters of certain types should get named according to the following list:
+     - `BlockPos` arguments should be named `pos` when the usage is obvious and `<subject>Pos` when
+       there is ambiguity or multiple parameters.
+     - Parameters of the `IWorldReaderBase` and related types should be called `worldIn`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # MCPBot_Reborn-Issues
 Issue tracker for MCPBot and MCP mappings.
 
+If you're planning to suggest name changes or are generally mapping, please make yourself familiar with
+our [conventions](CONVENTIONS.md).
+
 ## What this tracker is for:
 - Issues with using MCPBot_Reborn on irc.esper.net
 - Issues with mappings (wrong names, unnecessary name changes, etc)


### PR DESCRIPTION
## Motivation
With the increasing popularity of mapping things and the overall influx of changes, keeping certain quality standards becomes harder. There's been a lot of cleanup done in recent versions, but we still get bad *new* names, as can be seen from various issues created about bad 1.13 names.

Another goal we should strive for is consistency. Names are ultimately subjective, but a crowd sourced effort ought to adhere to a common style.

One of the issues people new to the mapping process face (which also effects long-time contributors) is the lack of a central place documenting conventions. There's tidbits spread out across issue comments and (private) conversations, but we do not have one definite source of truth.

## Approach
In order to tackle this, I've started working on a document outlining established naming conventions I've identified in issues and existing names. Some of them were taken from historical developments, things like `Obj` suffixes mostly are a thing of the past. They're still listed to be as clear as possible.

Do note that these are supposed to be **conventions**, not **rules**. There always will be exceptions, we can't provide more than a general guideline.

## Progress
The basics should be done, but I'd like to add some more examples. Suggestions are welcome, I'm not creative enough to come up with anything good.

All conventions are of course up for discussion. If you've got any input on formatting, structure or wording, please let me know.